### PR TITLE
bug fix for componentType is null

### DIFF
--- a/src/core/XMLParser.kt
+++ b/src/core/XMLParser.kt
@@ -50,7 +50,7 @@ class XMLParser<T>(var obj : Class<T>) {
                         f.set(_obj, tmpObject)
                     }
                 } else {
-                    val tmpObject = getNodeObject(element, f.type.componentType)
+                    val tmpObject = getNodeObject(element, f.type)
                     f.set(_obj, tmpObject)
                 }
             }


### PR DESCRIPTION
There is an error for the inner class handling.

class A {
    @JvmField var b: B? = null
}

class B {
    @JvmField var value: String? = null
}